### PR TITLE
fix(pipewire): label screencast node as screen capture

### DIFF
--- a/src/pipewire/pipewire.cpp
+++ b/src/pipewire/pipewire.cpp
@@ -685,9 +685,10 @@ namespace xdpu {
 
     pw_properties* props = pw_properties_new(
         PW_KEY_MEDIA_TYPE, "Video", PW_KEY_MEDIA_CATEGORY, "Capture", PW_KEY_MEDIA_ROLE, "Screen", PW_KEY_MEDIA_CLASS,
-        "Video/Source", PW_KEY_MEDIA_NAME, "umbriel-screencast", PW_KEY_NODE_NAME, "umbriel-screencast", nullptr
+        "Video/Source", PW_KEY_MEDIA_NAME, "umbriel-screen-capture", PW_KEY_NODE_NAME, "umbriel-screen-capture",
+        PW_KEY_NODE_DESCRIPTION, "Umbriel Screen Capture", nullptr
     );
-    stream->m_impl->stream = pw_stream_new(m_impl->core, "umbriel-screencast", props);
+    stream->m_impl->stream = pw_stream_new(m_impl->core, "umbriel-screen-capture", props);
     if (stream->m_impl->stream == nullptr) {
       fprintf(stderr, "pipewire: unable to create stream\n");
       return nullptr;


### PR DESCRIPTION
## Summary

This PR fix wrong OSD label, it was showing "Camera Active" Camera Inactive" while recording. Now shows Screen Sharing Active/Stopped

# The bug video:- 

from this PR:- https://github.com/noctalia-dev/umbriel/pull/20

https://github.com/user-attachments/assets/17d322fd-5235-42b5-bf05-677ee068a279

# Fix:



https://github.com/user-attachments/assets/4eab34a5-bcfc-4d68-a47e-efb7768c1172



