### PR TITLE
feat: only outer radius for header buttons

### DIFF
--- a/src/picker/style.css
+++ b/src/picker/style.css
@@ -30,6 +30,18 @@
   border-radius: @RADIUS@ @RADIUS@ 0 0;
 }
 
+.umbriel-picker headerbar stackswitcher button {
+  border-radius: 0;
+}
+
+.umbriel-picker headerbar stackswitcher button:first-child {
+  border-radius: @RADIUS@ 0 0 @RADIUS@;
+}
+
+.umbriel-picker headerbar stackswitcher button:last-child {
+  border-radius: 0 @RADIUS@ @RADIUS@ 0;
+}
+
 .umbriel-picker headerbar,
 .umbriel-picker stack,
 .umbriel-picker scrolledwindow,


### PR DESCRIPTION
Before:
<img width="289" height="45" alt="Screenshot from 2026-08-24 10-57-51 png-region" src="https://github.com/user-attachments/assets/01b7e578-55de-4d0a-930e-13f6e7541189" />
After:
<img width="295" height="46" alt="Screenshot from 2026-08-24 10-56-21 png-region" src="https://github.com/user-attachments/assets/2123d037-0087-4727-9624-d66eccf5249d" />
