### PR TITLE
fix(screencast): restore the window that was picked, not the first of its app

### DIFF
--- a/src/dbus/screencast.cpp
+++ b/src/dbus/screencast.cpp
@@ -140,6 +140,32 @@ namespace xdpu {
       return std::nullopt;
     }
 
+    std::optional<Session::Selection> parseMonitorEntry(const PortalResults& entry) {
+      const auto output = dictString(entry, "output");
+      if (!output || output->empty()) {
+        return std::nullopt;
+      }
+      Session::Selection selection;
+      selection.kind = Session::SourceKind::Monitor;
+      selection.output = *output;
+      selection.title = dictString(entry, "title").value_or(std::string{});
+      return selection;
+    }
+
+    std::optional<Session::Selection> parseEntry(const PortalResults& entry, RestoreDataVersion version) {
+      const auto kind = dictString(entry, "kind");
+      if (!kind) {
+        return std::nullopt;
+      }
+      if (*kind == "monitor") {
+        return parseMonitorEntry(entry);
+      }
+      if (*kind == "window") {
+        return parseWindowEntry(entry, version);
+      }
+      return std::nullopt;
+    }
+
     std::vector<Session::Selection> parseRestoreData(const PortalResults& options) {
       const auto it = options.find("restore_data");
       if (it == options.end() || !it->second.containsValueOfType<RestoreTuple>()) {
@@ -169,51 +195,52 @@ namespace xdpu {
       }
 
       std::vector<Session::Selection> selections;
+      selections.reserve(entries.size());
       for (const PortalResults& entry : entries) {
-        const auto kind = dictString(entry, "kind");
-        if (!kind) {
-          continue;
+        const auto selection = parseEntry(entry, *version);
+        if (!selection) {
+          return {};
         }
-
-        Session::Selection selection;
-        selection.title = dictString(entry, "title").value_or(std::string{});
-        if (*kind == "monitor") {
-          const auto output = dictString(entry, "output");
-          if (!output || output->empty()) {
-            continue;
-          }
-          selection.kind = Session::SourceKind::Monitor;
-          selection.output = *output;
-        } else if (*kind == "window") {
-          const auto window = parseWindowEntry(entry, *version);
-          if (!window) {
-            continue;
-          }
-          selection = *window;
-        } else {
-          continue;
-        }
-        selections.push_back(std::move(selection));
+        selections.push_back(*selection);
       }
       return selections;
     }
 
-    std::vector<Session::Selection> matchRestoreSelections(
+    std::optional<Session::Selection>
+    resolveSelection(const WaylandContext& wayland, const Session::Selection& stored) {
+      switch (stored.kind) {
+      case Session::SourceKind::Monitor:
+        if (const OutputInfo* output = findOutput(wayland, stored.output)) {
+          return selectionForOutput(*output);
+        }
+        return std::nullopt;
+
+      case Session::SourceKind::Window:
+        if (const ToplevelInfo* toplevel = findToplevelByIdentifier(wayland, stored.identifier)) {
+          return selectionForToplevel(*toplevel);
+        }
+        return std::nullopt;
+      }
+      return std::nullopt;
+    }
+
+    // Refused whole rather than narrowed: dropping a source the user chose is a
+    // silent substitution, and which one got dropped would depend on entry order.
+    std::vector<Session::Selection> resolveRestoreSelections(
         const WaylandContext& wayland, const std::vector<Session::Selection>& restore, bool multiple
     ) {
-      std::vector<Session::Selection> matches;
-      for (const Session::Selection& stored : restore) {
-        if (stored.kind == Session::SourceKind::Monitor) {
-          if (const OutputInfo* output = findOutput(wayland, stored.output)) {
-            matches.push_back(selectionForOutput(*output));
-          }
-        } else if (const ToplevelInfo* toplevel = findToplevelByIdentifier(wayland, stored.identifier)) {
-          matches.push_back(selectionForToplevel(*toplevel));
-        }
+      if (restore.empty() || (!multiple && restore.size() > 1)) {
+        return {};
+      }
 
-        if (!multiple && !matches.empty()) {
-          break;
+      std::vector<Session::Selection> matches;
+      matches.reserve(restore.size());
+      for (const Session::Selection& stored : restore) {
+        const auto live = resolveSelection(wayland, stored);
+        if (!live) {
+          return {};
         }
+        matches.push_back(*live);
       }
       return matches;
     }
@@ -469,7 +496,8 @@ namespace xdpu {
 
       void start(const std::string& handle) {
         attachRequest(handle);
-        const auto restored = matchRestoreSelections(portal.wayland, session->restoreSelections(), session->multiple());
+        const auto restored =
+            resolveRestoreSelections(portal.wayland, session->restoreSelections(), session->multiple());
         if (!restored.empty()) {
           startCaptures(restored);
           return;

--- a/src/dbus/screencast.cpp
+++ b/src/dbus/screencast.cpp
@@ -95,13 +95,6 @@ namespace xdpu {
       return it == toplevels.end() ? nullptr : &*it;
     }
 
-    const ToplevelInfo* findToplevelByAppId(const WaylandContext& wayland, const std::string& appId) {
-      const auto& toplevels = wayland.toplevels();
-      const auto it =
-          std::ranges::find_if(toplevels, [&](const ToplevelInfo& toplevel) { return toplevel.appId == appId; });
-      return it == toplevels.end() ? nullptr : &*it;
-    }
-
     Session::Selection selectionForOutput(const OutputInfo& output) {
       Session::Selection selection;
       selection.kind = Session::SourceKind::Monitor;
@@ -173,6 +166,8 @@ namespace xdpu {
           }
           selection.kind = Session::SourceKind::Window;
           selection.appId = *appId;
+          // Entries predating this key have no identifier, so they cannot match and fall through to the chooser.
+          selection.identifier = dictString(entry, "identifier").value_or(std::string{});
         } else {
           continue;
         }
@@ -190,7 +185,7 @@ namespace xdpu {
           if (const OutputInfo* output = findOutput(wayland, stored.output)) {
             matches.push_back(selectionForOutput(*output));
           }
-        } else if (const ToplevelInfo* toplevel = findToplevelByAppId(wayland, stored.appId)) {
+        } else if (const ToplevelInfo* toplevel = findToplevelByIdentifier(wayland, stored.identifier)) {
           matches.push_back(selectionForToplevel(*toplevel));
         }
 
@@ -305,6 +300,7 @@ namespace xdpu {
         entry["title"] = selection.title;
         if (selection.kind == Session::SourceKind::Window) {
           entry["app_id"] = selection.appId;
+          entry["identifier"] = selection.identifier;
         } else {
           entry["output"] = selection.output;
         }

--- a/src/dbus/screencast.cpp
+++ b/src/dbus/screencast.cpp
@@ -116,6 +116,30 @@ namespace xdpu {
       return selection;
     }
 
+    std::optional<Session::Selection> parseWindowEntry(const PortalResults& entry, RestoreDataVersion version) {
+      switch (version) {
+      case RestoreDataVersion::AppIdOnly:
+        // An intermediate build wrote identifiers into records still labelled AppIdOnly, so one
+        // may be present; it predates the guarantee, so prompt rather than trust it.
+        return std::nullopt;
+
+      case RestoreDataVersion::Identifier: {
+        // The protocol guarantees a nonempty identifier, not a nonempty app_id.
+        const auto identifier = dictString(entry, "identifier");
+        if (!identifier || identifier->empty()) {
+          return std::nullopt;
+        }
+        Session::Selection selection;
+        selection.kind = Session::SourceKind::Window;
+        selection.identifier = *identifier;
+        selection.appId = dictString(entry, "app_id").value_or(std::string{});
+        selection.title = dictString(entry, "title").value_or(std::string{});
+        return selection;
+      }
+      }
+      return std::nullopt;
+    }
+
     std::vector<Session::Selection> parseRestoreData(const PortalResults& options) {
       const auto it = options.find("restore_data");
       if (it == options.end() || !it->second.containsValueOfType<RestoreTuple>()) {
@@ -129,7 +153,8 @@ namespace xdpu {
         return {};
       }
 
-      if (std::get<0>(restore) != "umbriel" || std::get<1>(restore) != 1) {
+      const auto version = restoreDataVersionFromWire(std::get<1>(restore));
+      if (std::get<0>(restore) != "umbriel" || !version) {
         return {};
       }
 
@@ -160,14 +185,11 @@ namespace xdpu {
           selection.kind = Session::SourceKind::Monitor;
           selection.output = *output;
         } else if (*kind == "window") {
-          const auto appId = dictString(entry, "app_id");
-          if (!appId || appId->empty()) {
+          const auto window = parseWindowEntry(entry, *version);
+          if (!window) {
             continue;
           }
-          selection.kind = Session::SourceKind::Window;
-          selection.appId = *appId;
-          // Entries predating this key have no identifier, so they cannot match and fall through to the chooser.
-          selection.identifier = dictString(entry, "identifier").value_or(std::string{});
+          selection = *window;
         } else {
           continue;
         }

--- a/src/dbus/session.cpp
+++ b/src/dbus/session.cpp
@@ -423,15 +423,15 @@ namespace xdpu {
       if (selection.kind == SourceKind::Monitor) {
         entry.emplace("output", sdbus::Variant{selection.output});
       } else {
-        entry.emplace("app_id", sdbus::Variant{selection.appId});
         entry.emplace("identifier", sdbus::Variant{selection.identifier});
+        entry.emplace("app_id", sdbus::Variant{selection.appId});
       }
       entries.push_back(std::move(entry));
     }
 
-    return sdbus::Variant{
-        sdbus::Struct<std::string, uint32_t, sdbus::Variant>{"umbriel", uint32_t{1}, sdbus::Variant{entries}}
-    };
+    return sdbus::Variant{sdbus::Struct<std::string, uint32_t, sdbus::Variant>{
+        "umbriel", static_cast<uint32_t>(kRestoreDataVersion), sdbus::Variant{entries}
+    }};
   }
 
   void Session::clearStreams() { m_impl->clearStreams(); }

--- a/src/dbus/session.cpp
+++ b/src/dbus/session.cpp
@@ -424,6 +424,7 @@ namespace xdpu {
         entry.emplace("output", sdbus::Variant{selection.output});
       } else {
         entry.emplace("app_id", sdbus::Variant{selection.appId});
+        entry.emplace("identifier", sdbus::Variant{selection.identifier});
       }
       entries.push_back(std::move(entry));
     }

--- a/src/dbus/session.h
+++ b/src/dbus/session.h
@@ -3,8 +3,10 @@
 #include "dbus/request.h"
 #include "wayland/wayland.h"
 
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -12,6 +14,24 @@ namespace xdpu {
 
   class Loop;
   class PipeWireStream;
+
+  enum class RestoreDataVersion : uint32_t {
+    // Windows stored as app_id, which names an application that may have multiple windows.
+    AppIdOnly = 1,
+    // Windows stored with the ext-foreign-toplevel identifier.
+    Identifier = 2,
+  };
+
+  inline constexpr RestoreDataVersion kRestoreDataVersion = RestoreDataVersion::Identifier;
+
+  constexpr std::optional<RestoreDataVersion> restoreDataVersionFromWire(uint32_t wire) {
+    switch (static_cast<RestoreDataVersion>(wire)) {
+    case RestoreDataVersion::AppIdOnly:
+    case RestoreDataVersion::Identifier:
+      return static_cast<RestoreDataVersion>(wire);
+    }
+    return std::nullopt;
+  }
 
   class Session {
   public:


### PR DESCRIPTION
## Summary

A restored screencast resolved its stored window by `app_id` alone, so with several windows of one application it
streamed whichever sorted first by title — and because `Start()` takes the restore path before `runChooser()`, no picker appeared to correct it.

Three commits:

1. **Resolve by identifier.** Persist the window's `ext-foreign-toplevel` identifier and resolve with it, through the `findToplevelByIdentifier()` the chooser path already uses.
2. **Version the record.** Emit `restore_data` version `2`, accept `1` and `2`. Without this, a rollback to a  pre-identifier reader would parse a new record, find no key it recognises, and match by `app_id` again — silently reinstating the bug.
3. **All-or-nothing restore.** A record is honoured in full or not at all. Previously an entry that could not be decoded
   or resolved was dropped while the rest survived, so a record naming a monitor and a window restored the monitor alone  whenever the window had gone — again with no picker.

## Assumptions

These are the things the change takes to be true. Each is either a protocol guarantee, a specification sentence, or a
decision — the decisions are marked, and I would rather be told they are wrong than have them merged by default.

| # | Assumption | Basis |
|---|---|---|
| 1 | A toplevel identifier is non-empty and unique, and is never reused for another toplevel | `ext-foreign-toplevel-list-v1` |
| 2 | `app_id` guarantees nothing — it may be empty, and it names an application, not a window | protocol; it is metadata in the record now |
| 3 | An identifier is only valid while its toplevel is mapped | protocol — so `persist_mode 2` across a reboot prompts once |
| 4 | Falling through to the picker is the correct answer when a stored session cannot be restored | ScreenCast spec: *"If the stored session cannot be restored, this value is ignored and the user will be prompted normally … a window that is not available anymore"* |
| 5 | `restore_data` is a private contract between this backend and its future self | it is opaque to the frontend, hence a private version |
| 6 | A v1 window record names an application rather than a window, so it can never be resolved exactly | it predates the identifier |
| 7 | A v1 record carrying an identifier is not to be trusted | commit 1 wrote identifiers into records it still labelled v1, so that shape exists; reading it means trusting a key that version never defined |
| 8 | Monitor records mean the same thing in v1 and v2 | nothing about them changed, so nothing branches on the version for them |
| 9 | **Decision:** restore is all-or-nothing — a record honoured in part is not honoured | partial restore hands the caller a different set of sources than the user consented to, without saying so |
| 10 | **Decision:** a record naming more sources than the replaying session can take is refused, not narrowed | such a record can only have been written by a session that asked for several; narrowing drops a source the user chose, and *which* one depended on entry order. Costs one prompt, once — the selection made at that prompt replaces the record |

Assumption 10 is the one I am least certain of and the easiest to change: it is pinned by exactly two test cases (26 and 27 below), and flipping them chooses the other reading. I went strict because this PR's whole argument is that a silent wrong source is worse than an extra prompt, but if you would rather narrow, say so and I will flip it.

**Behaviour change worth flagging:** a `persist_mode 2` session restored after its window is gone now prompts once instead of substituting a same-app window. With two windows open, the previous behaviour was a coin flip, not an approximation of the right answer. If you want a fallback for that case later, GNOME's shape — `app_id` plus a title edit distance with an explicit refusal threshold — is a bounded guess and a separate decision from stopping the
unbounded one, so it is not bundled here.

## Related issue

Closes #4.

## Testing

Built against nixpkgs' recipe with the patched source; `clang-format` via `just format` leaves the diff unchanged.

Verified on a live Umbriel session by a harness that drives `org.freedesktop.impl.portal.desktop.umbriel` directly. That matters for reach: the frontend owns the token → `restore_data` mapping, so a normal client can only ever replay records the backend authored itself — never a legacy record, nor one with a field deliberately missing.

**How a case reaches a verdict.** Three same-app `kitty` windows are up — `harness-aaaa`, `harness-bbbb` and
`0000-cccc`, the last sorting *first* deliberately so "restored the right window" cannot be confused with "restored the oldest". Every crafted record names `harness-bbbb`; the scripted picker is armed to answer `harness-aaaa`. The verdict asserts all of: whether the picker actually ran, the source types of the streams that started, and the dominant colour of a captured frame. The picker flag is there because a frame alone cannot separate "the picker chose this window" from "a monitor capture is nearest this colour"; the frame is there because asserting only that the picker ran would pass against a backend that ran it and then ignored the answer.

### The cases

| # | Given | When | Then |
|---|---|---|---|
| 0 | a live pick stored with `persist_mode` transient | the backend hands back `restore_data` | it is version 2 and carries the picked window's identifier |
| 1 | a record naming a backend other than umbriel | replayed at `Start` | the picker opens |
| 2 | a record carrying a version this backend does not understand | replayed at `Start` | the picker opens |
| 3 | a v2 record with no entries at all | replayed at `Start` | the picker opens |
| 4 | a v2 record whose payload is not an entry array | replayed at `Start` | the picker opens |
| 5 | a v2 window record naming one of three same-app windows | replayed at `Start` | that exact window streams |
| 6 | a v2 window record with a valid identifier and an empty app id | replayed at `Start` | the window streams, because app_id is metadata |
| 7 | a v2 window record with a valid identifier and no app id key | replayed at `Start` | the window streams, because absent is the same as empty |
| 8 | a v2 window record with an app id but no identifier | replayed at `Start` | the picker opens, with no quiet fallback to app_id |
| 9 | a v2 window record whose identifier is present but empty | replayed at `Start` | the picker opens |
| 10 | a v1 window record carrying only an app id | replayed at `Start` | the picker opens, because app_id names an application not a window |
| 11 | a v1 window record carrying a valid identifier | replayed at `Start` | the picker opens, because v1 never defined that key |
| 12 | a v2 monitor record naming a live output | replayed at `Start` | the monitor streams |
| 13 | a v1 monitor record naming a live output | replayed at `Start` | the monitor streams, because the v1 gate is scoped to windows |
| 14 | a v2 monitor record naming an output that is not live | replayed at `Start` | the picker opens |
| 15 | a v2 monitor record whose output is present but empty | replayed at `Start` | the picker opens |
| 16 | a v2 monitor record with no output key | replayed at `Start` | the picker opens |
| 17 | a v2 record whose entry kind is unrecognised | replayed at `Start` | the picker opens |
| 18 | a v2 record whose entry has no kind key | replayed at `Start` | the picker opens |
| 19 | a v2 record naming a live monitor and a live window | replayed, session asks `multiple` | both sources stream and the picker stays shut |
| 20 | a v2 record naming two live windows | replayed, session asks `multiple` | both windows stream and the picker stays shut |
| 21 | a v1 record naming a live monitor and a window | replayed, session asks `multiple` | the picker opens, because the monitor must not start alone |
| 22 | a v2 record naming a live monitor and a window that is gone | replayed, session asks `multiple` | the picker opens, because the monitor must not start alone |
| 23 | a v2 record naming a live window and a monitor that is gone | replayed, session asks `multiple` | the picker opens, because the window must not start alone |
| 24 | a v2 record whose first entry is a window that is gone and whose second is a live monitor | replayed, session asks `multiple` | the picker opens, so order does not decide the verdict |
| 25 | a v2 record naming one live window and one that is gone | replayed, session asks `multiple` | the picker opens |
| 26 | a v2 record naming a live monitor and a window that is gone | replayed, session does **not** ask `multiple` | the picker opens, because a record honoured in part is not honoured |
| 27 | a v2 record naming a live monitor and a live window | replayed, session does **not** ask `multiple` | the picker opens, because the session cannot take everything the record names |

**All 28 hold** against this branch, on the real system build.

Cases 19 and 20 are load-bearing in a way the others are not: they must *restore*. Without them, an implementation that simply never restores anything would satisfy every "the picker opens" row and the suite would be green for free.

Seven cases were red before commit 3 — 21 through 27. Cases 26 and 27 are the pair that pins assumption 10, and 27 is the only case that separates "refuse" from "resolve everything, then narrow".

### Beyond the pass list

- **Cross-build check.** The suite is run against three builds — this PR's base, commit 1, commit 2 — so the verdicts
  are shown to *move* rather than just to pass. A row that reads the same in every column is a boundary guard, not a regression detector, and is reported as such.
- **Mutation check.** Every case is re-run with its expectation inverted. A case that holds *both* ways asserts nothing; all 27 fail the inverted reading, so none is vacuous.
- **The SHM probe still passes**, including the DMA-BUF format count — this refactor touches the same file as #8, so that is a regression check rather than a formality.
- Both `persist_mode` 1 and 2 exercised.

## Checklist

- [x] This PR is ready for review, or is marked as a draft.
- [x] I ran the relevant build, test, or verification commands.
- [x] I manually tested the affected portal flow when practical.
- [x] I self-reviewed the changes.