### PR TITLE
fix(wayland): decode shm_format as wl_shm.format, not a DRM fourcc

### DIFF
--- a/src/pipewire/pipewire.cpp
+++ b/src/pipewire/pipewire.cpp
@@ -512,6 +512,10 @@ namespace xdpu {
       for (uint32_t shmFormat : impl.constraints.shmFormats) {
         if (auto spa = drmToSpa(shmFormat)) {
           list.addVideoFormat(impl.width, impl.height, *spa, std::nullopt, impl.maxFps);
+        } else {
+          // Say so: a consumer that cannot import dmabuf sees only "no more
+          // input formats" on its side, with nothing here naming the cause.
+          fprintf(stderr, "pipewire: shm format 0x%08x has no SPA mapping; not advertised\n", shmFormat);
         }
       }
       return list;

--- a/src/wayland/wayland.cpp
+++ b/src/wayland/wayland.cpp
@@ -362,6 +362,35 @@ namespace xdpu {
         .description = onOutputDescription,
     };
 
+    // ext_image_copy_capture_session_v1.shm_format carries a wl_shm.format value,
+    // not a DRM fourcc. The two agree for every format except the two wl_shm
+    // defines itself: ARGB8888 is 0 and XRGB8888 is 1, where the fourcc would be
+    // 'AR24' and 'XR24'. Everything past the listener speaks DRM fourcc (the
+    // SPA table, bytes-per-pixel, the dmabuf constraints), so the enum is
+    // converted away here and converted back only where wl_shm itself is
+    // spoken to, in createShmBuffer().
+    uint32_t drmFormatFromWlShm(uint32_t wlShmFormat) {
+      switch (wlShmFormat) {
+      case WL_SHM_FORMAT_ARGB8888:
+        return DRM_FORMAT_ARGB8888;
+      case WL_SHM_FORMAT_XRGB8888:
+        return DRM_FORMAT_XRGB8888;
+      default:
+        return wlShmFormat;
+      }
+    }
+
+    uint32_t wlShmFormatFromDrm(uint32_t drmFormat) {
+      switch (drmFormat) {
+      case DRM_FORMAT_ARGB8888:
+        return WL_SHM_FORMAT_ARGB8888;
+      case DRM_FORMAT_XRGB8888:
+        return WL_SHM_FORMAT_XRGB8888;
+      default:
+        return drmFormat;
+      }
+    }
+
     void onSessionBufferSize(void* data, ext_image_copy_capture_session_v1* session, uint32_t width, uint32_t height) {
       (void)session;
       auto* capture = static_cast<WaylandContext::CaptureSession*>(data);
@@ -372,7 +401,7 @@ namespace xdpu {
     void onSessionShmFormat(void* data, ext_image_copy_capture_session_v1* session, uint32_t format) {
       (void)session;
       auto* capture = static_cast<WaylandContext::CaptureSession*>(data);
-      capture->pendingConstraints.shmFormats.push_back(format);
+      capture->pendingConstraints.shmFormats.push_back(drmFormatFromWlShm(format));
     }
 
     void onSessionDmabufDevice(void* data, ext_image_copy_capture_session_v1* session, wl_array* device) {
@@ -863,7 +892,8 @@ namespace xdpu {
       return nullptr;
     }
     wl_buffer* buffer = wl_shm_pool_create_buffer(
-        pool, 0, static_cast<int32_t>(width), static_cast<int32_t>(height), static_cast<int32_t>(stride), format
+        pool, 0, static_cast<int32_t>(width), static_cast<int32_t>(height), static_cast<int32_t>(stride),
+        wlShmFormatFromDrm(format)
     );
     wl_shm_pool_destroy(pool);
     m_impl->flushDisplay();
@@ -887,7 +917,8 @@ namespace xdpu {
   WaylandContext* WaylandContext::defaultContext() { return g_defaultContext; }
 
   uint32_t WaylandContext::preferredShmFormat(const std::vector<uint32_t>& formats) {
-    // Capture protocol shm_format events use DRM fourcc values, not wl_shm enum.
+    // Constraints hold DRM fourcc values; the session listener has already
+    // converted the wl_shm.format the protocol event carries.
     const auto has = [&](uint32_t fmt) { return std::ranges::find(formats, fmt) != formats.end(); };
     if (has(DRM_FORMAT_XRGB8888)) {
       return DRM_FORMAT_XRGB8888;

--- a/src/wayland/wayland.h
+++ b/src/wayland/wayland.h
@@ -52,7 +52,7 @@ namespace xdpu {
   struct CaptureConstraints {
     uint32_t bufferWidth = 0;
     uint32_t bufferHeight = 0;
-    std::vector<uint32_t> shmFormats;
+    std::vector<uint32_t> shmFormats; // DRM fourcc, converted from wl_shm.format on receipt
     dev_t dmabufDevice = 0;
 
     struct DmabufFormat {
@@ -142,6 +142,7 @@ namespace xdpu {
     struct wl_buffer* createDmabufBuffer(
         uint32_t width, uint32_t height, uint32_t format, uint64_t modifier, const std::vector<DmabufPlane>& planes
     );
+    // `format` is a DRM fourcc; the wl_shm.format value is derived internally.
     struct wl_buffer*
     createShmBuffer(uint32_t width, uint32_t height, uint32_t format, uint32_t stride, int fd, size_t size);
 


### PR DESCRIPTION
## Summary

`ext_image_copy_capture_session_v1.shm_format` carries a `wl_shm.format` value, but the portal compared it against DRM fourcc constants. The two differ only for `XRGB8888` (`1`) and `ARGB8888` (`0`), which are the formats a compositor most often offers, so the SHM format was dropped silently: the screencast node advertised DMA-BUF only, and every non-interactive screenshot failed on the same value.

This converts at the edge: `wl_shm.format` → fourcc when the event arrives (`onSessionShmFormat()`), and back to `wl_shm.format` only in `createShmBuffer()`, the one place `wl_shm` is spoken to. Both directions are needed — converting only on receipt would hand `wl_shm` a fourcc and turn the screenshot failure into a protocol error. The comment at `preferredShmFormat()` that stated the opposite of the protocol is corrected, and `buildFormatParams()` now logs an shm format it cannot map, so the next silent drop names itself.

## Related issue

Closes #7.

## Testing

Each check below is a before/after pair. Run it once on `main`, apply this branch, run it again. All three fail before and pass after; the DMA-BUF path is unchanged throughout.

**1. The screencast node advertises an SHM format.** Start any screen share (a browser sharing a window is enough), then read the portal node's formats:

```sh
pw-dump | jq '.[] | select(.info.props."node.name" == "umbriel-screen-capture") | .info.params.EnumFormat'
```

Before: every entry has a `modifier` (DMA-BUF). After: one entry has no `modifier` (SHM), typically `BGRx`.

**2. A consumer without dma-buf import gets a picture.** The reproduction from #7 — Chrome with the render node hidden, so WebRTC falls back to SHM:

```sh
bwrap --ro-bind / / --dev /dev --tmpfs /dev/dri --proc /proc --bind /run /run --bind /tmp /tmp \
  google-chrome-stable --no-sandbox --user-data-dir=/tmp/chrome-noshm
```

Share to https://webrtc.github.io/samples/src/content/getusermedia/getdisplaymedia/ and press Start. Before: the video stays black and Chrome logs `PipeWire stream state error: no more input formats`. After: the picture shows. (The MESA EGL errors from the hidden render node appear on both runs; they are the point, not a regression.)

A dependency-free equivalent, if you would rather not launch Chrome — a CPU-only GStreamer pipeline can take nothing but SHM. With a share running:

```sh
node=$(pw-dump | jq '.[] | select(.info.props."node.name" == "umbriel-screen-capture") | .id')
gst-launch-1.0 pipewiresrc path=$node ! videoconvert ! fakesink
```

Before: `Failed to set pipeline to PAUSED` (nothing to negotiate). After: it rolls.

**3. The Screenshot portal returns an image.** It must be one connection that stays open until the response arrives; a one-shot `busctl call` disconnects first and the portal cancels the request, so use a short client:

```python
python3 - <<'PY'
import gi; gi.require_version("Gio", "2.0")
from gi.repository import Gio, GLib
bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
res = bus.call_sync("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop",
                    "org.freedesktop.portal.Screenshot", "Screenshot",
                    GLib.Variant("(sa{sv})", ("", {"interactive": GLib.Variant("b", False)})),
                    None, Gio.DBusCallFlags.NONE, -1, None)
loop = GLib.MainLoop()
bus.signal_subscribe("org.freedesktop.portal.Desktop", "org.freedesktop.portal.Request", "Response",
                     res.unpack()[0], None, Gio.DBusSignalFlags.NONE,
                     lambda *a: (print("response", a[-1].unpack()), loop.quit()))
loop.run()
PY
```

Before: `response (2, {})`, and the portal's journal shows `screenshot: unsupported screenshot DRM format 0x00000001`. After: `response (0, {'uri': 'file://…png'})`, a real capture of the first output.

Notes: I built against nixpkgs' recipe with the patched source (`just format` leaves the diff unchanged). Consumers that already import dma-buf (Chrome with GPU access, Teams for Linux) negotiate DMA-BUF before and after, unaffected. Environment: Umbriel `0-unstable-2026-08-30`, wlroots 0.20.2, NVIDIA proprietary driver, NixOS.

## Checklist

- [x] This PR is ready for review, or is marked as a draft.
- [x] I ran the relevant build, test, or verification commands.
- [x] I manually tested the affected portal flow when practical.
- [x] I self-reviewed the changes.