### PR TITLE
feat(picker): add responsive source previews and selection grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ nix build
 
 A dev shell is also available via `nix develop`.
 
+## Share picker
+
+The picker shows screen and window thumbnails in a responsive grid. Click a card
+and choose **Share**; requests that allow multiple sources support clicking cards
+to select or deselect them, including across tabs. Space toggles a focused card in
+multiple-selection mode, Enter shares, and Escape cancels.
+
+Window decorations are delegated to the compositor. Controls follow Umbriel's
+live palette and corner radius, with GTK theme colors as a fallback. The picker
+defaults to Cairo rendering to avoid GPU renderer startup and shutdown overhead;
+an explicit `GSK_RENDERER` environment setting still takes precedence.
+
+Screen and window previews are snapshots taken as cards become visible using the same Wayland image
+capture protocols as screencasting. Hidden tabs and offscreen cards are deferred.
+Each capture session is destroyed and its cleanup acknowledged before the worker
+goes idle. Snapshots load asynchronously, remain in memory,
+and are discarded when the picker closes. Sources without a supported preview
+remain selectable with a placeholder. The chooser's JSON input/output format is
+unchanged. Window capture requires Umbriel's fix for output membership and frame
+pacing across the desktop and capture scenes. Older compositor builds can leave
+applications waiting for frame callbacks after a window capture ends.
+
 ## Configuration
 
 The config file lives at `$XDG_CONFIG_HOME/xdg-desktop-portal-umbriel/config.toml` (or the system-installed default).

--- a/meson.build
+++ b/meson.build
@@ -109,9 +109,14 @@ if gtk4_dep.found()
   )
   executable(
     'umbriel-share-picker',
-    files('src/picker/main.cpp') + picker_resources,
-    include_directories: include_directories('src'),
-    dependencies: [gtk4_dep, nlohmann_json_dep],
+    files(
+      'src/picker/main.cpp',
+      'src/picker/previews.cpp',
+      'src/wayland/wayland.cpp',
+      'src/loop/loop.cpp',
+    ) + picker_resources + protocol_sources,
+    include_directories: [include_directories('src'), include_directories('.')],
+    dependencies: [gtk4_dep, nlohmann_json_dep, wayland_client_dep, libdrm_dep, dependency('threads')],
     install: true,
     install_dir: get_option('libexecdir'),
   )

--- a/src/picker/main.cpp
+++ b/src/picker/main.cpp
@@ -1,3 +1,6 @@
+#include "picker/previews.h"
+
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -62,6 +65,12 @@ namespace {
     GtkWidget* outputList = nullptr;
     GtkWidget* windowList = nullptr;
     GtkWidget* shareButton = nullptr;
+    GtkWidget* selectionLabel = nullptr;
+    std::vector<xdpu::PreviewSource> previewSources;
+    std::vector<GtkWidget*> previewStacks;
+    std::unique_ptr<xdpu::Previews> previews;
+    guint previewWatch = 0;
+    size_t previewsLoaded = 0;
     GtkCssProvider* paletteProvider = nullptr;
     GdkDisplay* display = nullptr;
     int paletteFd = -1;
@@ -405,6 +414,14 @@ namespace {
       return;
     }
     state.responding = true;
+    if (state.previews) {
+      state.previews->stop();
+    }
+    // Unmap before waiting for preview cleanup so the compositor can return focus.
+    if (state.window != nullptr) {
+      gtk_widget_set_visible(state.window, FALSE);
+      gdk_display_flush(state.display);
+    }
     printResponse(response);
     if (state.app != nullptr) {
       g_application_quit(G_APPLICATION(state.app));
@@ -417,7 +434,7 @@ namespace {
     if (list == nullptr) {
       return nullptr;
     }
-    return gtk_list_box_get_selected_rows(GTK_LIST_BOX(list));
+    return gtk_flow_box_get_selected_children(GTK_FLOW_BOX(list));
   }
 
   bool hasSelection(GtkWidget* list) {
@@ -431,30 +448,35 @@ namespace {
     if (state.shareButton == nullptr) {
       return;
     }
-    gtk_widget_set_sensitive(state.shareButton, hasSelection(state.outputList) || hasSelection(state.windowList));
+    GList* screens = selectedRows(state.outputList);
+    GList* windows = selectedRows(state.windowList);
+    const guint count = g_list_length(screens) + g_list_length(windows);
+    g_list_free(screens);
+    g_list_free(windows);
+    gtk_widget_set_sensitive(state.shareButton, count > 0);
+    if (state.selectionLabel != nullptr) {
+      const std::string text = count == 0
+          ? "Nothing selected"
+          : std::to_string(count) + (count == 1 ? " source selected" : " sources selected");
+      gtk_label_set_text(GTK_LABEL(state.selectionLabel), text.c_str());
+    }
   }
 
   void unselectList(GtkWidget* list) {
     if (list != nullptr) {
-      gtk_list_box_unselect_all(GTK_LIST_BOX(list));
+      gtk_flow_box_unselect_all(GTK_FLOW_BOX(list));
     }
   }
 
-  void onSelectedRowsChanged(GtkListBox* list, gpointer userData) {
+  void onSelectedRowsChanged(GtkFlowBox* list, gpointer userData) {
     auto* state = static_cast<AppState*>(userData);
     if (state->updatingSelection) {
-      updateShareButton(*state);
       return;
     }
 
     if (!state->multiple && hasSelection(GTK_WIDGET(list))) {
       state->updatingSelection = true;
-      if (GTK_WIDGET(list) != state->outputList) {
-        unselectList(state->outputList);
-      }
-      if (GTK_WIDGET(list) != state->windowList) {
-        unselectList(state->windowList);
-      }
+      unselectList(GTK_WIDGET(list) == state->outputList ? state->windowList : state->outputList);
       state->updatingSelection = false;
     }
 
@@ -486,85 +508,230 @@ namespace {
     return label;
   }
 
-  GtkWidget* makeOutputRow(const OutputItem& output, guint index) {
-    GtkWidget* row = gtk_list_box_row_new();
-    g_object_set_data(G_OBJECT(row), "xdpu-kind", GINT_TO_POINTER(static_cast<int>(RowKind::Monitor)));
-    g_object_set_data(G_OBJECT(row), "xdpu-index", GUINT_TO_POINTER(index));
-
-    GtkWidget* box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
-    gtk_widget_set_margin_top(box, 10);
-    gtk_widget_set_margin_bottom(box, 10);
-    gtk_widget_set_margin_start(box, 12);
-    gtk_widget_set_margin_end(box, 12);
-
-    GtkWidget* textBox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 3);
-    gtk_widget_set_hexpand(textBox, TRUE);
-    gtk_box_append(GTK_BOX(textBox), makeLabel(displayOrFallback(output.name, "Unnamed screen"), true, false));
-    gtk_box_append(GTK_BOX(textBox), makeLabel(output.description, false, true));
-
-    const std::string detail = std::to_string(output.width) + "×" + std::to_string(output.height);
-    GtkWidget* detailLabel = makeLabel(detail, false, true);
-    gtk_label_set_xalign(GTK_LABEL(detailLabel), 1.0F);
-
-    gtk_box_append(GTK_BOX(box), textBox);
-    gtk_box_append(GTK_BOX(box), detailLabel);
-    gtk_list_box_row_set_child(GTK_LIST_BOX_ROW(row), box);
-    return row;
+  GtkWidget* makePreview(AppState& state, RowKind kind, const std::string& identifier) {
+    GtkWidget* stack = gtk_stack_new();
+    gtk_widget_add_css_class(stack, "preview");
+    gtk_widget_set_size_request(stack, 210, 132);
+    gtk_widget_set_overflow(stack, GTK_OVERFLOW_HIDDEN);
+    GtkWidget* fallback = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_valign(fallback, GTK_ALIGN_CENTER);
+    GtkWidget* icon = gtk_image_new_from_icon_name(
+        kind == RowKind::Monitor ? "video-display-symbolic" : "application-x-executable-symbolic"
+    );
+    gtk_image_set_pixel_size(GTK_IMAGE(icon), 32);
+    gtk_box_append(GTK_BOX(fallback), icon);
+    GtkWidget* label = gtk_label_new("Loading preview…");
+    gtk_widget_add_css_class(label, "preview-caption");
+    gtk_box_append(GTK_BOX(fallback), label);
+    g_object_set_data(G_OBJECT(stack), "preview-label", label);
+    gtk_stack_add_named(GTK_STACK(stack), fallback, "fallback");
+    state.previewSources.push_back({kind == RowKind::Monitor, identifier});
+    state.previewStacks.push_back(stack);
+    return stack;
   }
 
-  GtkWidget* makeWindowRow(const WindowItem& window, guint index) {
-    GtkWidget* row = gtk_list_box_row_new();
-    g_object_set_data(G_OBJECT(row), "xdpu-kind", GINT_TO_POINTER(static_cast<int>(RowKind::Window)));
+  void toggleSource(GtkFlowBoxChild* child) {
+    auto* grid = GTK_FLOW_BOX(gtk_widget_get_parent(GTK_WIDGET(child)));
+    const bool selected = gtk_flow_box_child_is_selected(child);
+    gtk_widget_grab_focus(GTK_WIDGET(child));
+    if (selected) {
+      gtk_flow_box_unselect_child(grid, child);
+    } else {
+      gtk_flow_box_select_child(grid, child);
+    }
+  }
+
+  GtkWidget* makeCard(
+      AppState& state, RowKind kind, guint index, const std::string& identifier, const std::string& title,
+      const std::string& subtitle, const std::string& detail
+  ) {
+    GtkWidget* row = gtk_flow_box_child_new();
+    gtk_widget_add_css_class(row, "source-card");
+    g_object_set_data(G_OBJECT(row), "xdpu-kind", GINT_TO_POINTER(static_cast<int>(kind)));
     g_object_set_data(G_OBJECT(row), "xdpu-index", GUINT_TO_POINTER(index));
+    gtk_widget_set_tooltip_text(row, (title + "\n" + subtitle).c_str());
 
-    GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 3);
-    gtk_widget_set_margin_top(box, 10);
-    gtk_widget_set_margin_bottom(box, 10);
-    gtk_widget_set_margin_start(box, 12);
-    gtk_widget_set_margin_end(box, 12);
+    GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    GtkWidget* overlay = gtk_overlay_new();
+    gtk_overlay_set_child(GTK_OVERLAY(overlay), makePreview(state, kind, identifier));
+    GtkWidget* check = gtk_image_new_from_icon_name("object-select-symbolic");
+    gtk_widget_add_css_class(check, "selection-check");
+    gtk_widget_set_halign(check, GTK_ALIGN_END);
+    gtk_widget_set_valign(check, GTK_ALIGN_START);
+    gtk_overlay_add_overlay(GTK_OVERLAY(overlay), check);
+    gtk_box_append(GTK_BOX(box), overlay);
 
-    gtk_box_append(GTK_BOX(box), makeLabel(displayOrFallback(window.title, "Untitled window"), false, false));
-    gtk_box_append(GTK_BOX(box), makeLabel(window.appId, false, true));
-
-    gtk_list_box_row_set_child(GTK_LIST_BOX_ROW(row), box);
+    GtkWidget* labels = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_add_css_class(labels, "card-labels");
+    GtkWidget* titleLabel = makeLabel(title, true, false);
+    GtkWidget* subtitleLabel = makeLabel(subtitle, false, true);
+    gtk_label_set_max_width_chars(GTK_LABEL(titleLabel), 20);
+    gtk_label_set_max_width_chars(GTK_LABEL(subtitleLabel), 20);
+    gtk_box_append(GTK_BOX(labels), titleLabel);
+    gtk_box_append(GTK_BOX(labels), subtitleLabel);
+    if (!detail.empty()) {
+      GtkWidget* detailLabel = makeLabel(detail, false, true);
+      gtk_widget_add_css_class(detailLabel, "source-detail");
+      gtk_box_append(GTK_BOX(labels), detailLabel);
+    }
+    gtk_box_append(GTK_BOX(box), labels);
+    gtk_flow_box_child_set_child(GTK_FLOW_BOX_CHILD(row), box);
+    if (state.multiple) {
+      GtkGesture* click = gtk_gesture_click_new();
+      gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(click), GDK_BUTTON_PRIMARY);
+      gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(click), GTK_PHASE_CAPTURE);
+      g_signal_connect(
+          click, "pressed", G_CALLBACK(+[](GtkGestureClick* gesture, int, double, double, gpointer data) {
+            gtk_gesture_set_state(GTK_GESTURE(gesture), GTK_EVENT_SEQUENCE_CLAIMED);
+            toggleSource(GTK_FLOW_BOX_CHILD(data));
+          }),
+          row
+      );
+      gtk_widget_add_controller(row, GTK_EVENT_CONTROLLER(click));
+    }
     return row;
   }
 
   GtkWidget* makePlaceholder(const char* text) {
     GtkWidget* label = gtk_label_new(text);
-    gtk_widget_set_margin_top(label, 24);
-    gtk_widget_set_margin_bottom(label, 24);
+    gtk_widget_set_margin_top(label, 48);
+    gtk_widget_set_margin_bottom(label, 48);
     gtk_widget_add_css_class(label, "dim-label");
     return label;
   }
 
-  GtkWidget* makeListBox(AppState& state, RowKind kind) {
-    GtkWidget* list = gtk_list_box_new();
-    gtk_list_box_set_selection_mode(GTK_LIST_BOX(list), state.multiple ? GTK_SELECTION_MULTIPLE : GTK_SELECTION_SINGLE);
-    gtk_list_box_set_activate_on_single_click(GTK_LIST_BOX(list), TRUE);
-    g_signal_connect(list, "selected-rows-changed", G_CALLBACK(onSelectedRowsChanged), &state);
+  GtkWidget* makeSourceGrid(AppState& state, RowKind kind) {
+    GtkWidget* list = gtk_flow_box_new();
+    gtk_widget_add_css_class(list, "source-grid");
+    gtk_widget_set_valign(list, GTK_ALIGN_START);
+    gtk_flow_box_set_homogeneous(GTK_FLOW_BOX(list), TRUE);
+    gtk_flow_box_set_min_children_per_line(GTK_FLOW_BOX(list), 1);
+    gtk_flow_box_set_max_children_per_line(GTK_FLOW_BOX(list), 3);
+    gtk_flow_box_set_row_spacing(GTK_FLOW_BOX(list), 12);
+    gtk_flow_box_set_column_spacing(GTK_FLOW_BOX(list), 12);
+    gtk_flow_box_set_selection_mode(GTK_FLOW_BOX(list), state.multiple ? GTK_SELECTION_MULTIPLE : GTK_SELECTION_SINGLE);
+    gtk_flow_box_set_activate_on_single_click(GTK_FLOW_BOX(list), TRUE);
+    g_signal_connect(list, "selected-children-changed", G_CALLBACK(onSelectedRowsChanged), &state);
 
     if (kind == RowKind::Monitor) {
-      gtk_list_box_set_placeholder(GTK_LIST_BOX(list), makePlaceholder("No screens available"));
       for (size_t i = 0; i < state.outputs.size(); ++i) {
-        gtk_list_box_append(GTK_LIST_BOX(list), makeOutputRow(state.outputs[i], static_cast<guint>(i)));
+        const auto& output = state.outputs[i];
+        const std::string detail = output.width > 0 && output.height > 0
+            ? std::to_string(output.width) + " × " + std::to_string(output.height)
+            : "";
+        gtk_flow_box_insert(
+            GTK_FLOW_BOX(list),
+            makeCard(
+                state, kind, static_cast<guint>(i), output.name, displayOrFallback(output.name, "Unnamed screen"),
+                output.description, detail
+            ),
+            -1
+        );
       }
     } else {
-      gtk_list_box_set_placeholder(GTK_LIST_BOX(list), makePlaceholder("No windows available"));
       for (size_t i = 0; i < state.windows.size(); ++i) {
-        gtk_list_box_append(GTK_LIST_BOX(list), makeWindowRow(state.windows[i], static_cast<guint>(i)));
+        const auto& window = state.windows[i];
+        gtk_flow_box_insert(
+            GTK_FLOW_BOX(list),
+            makeCard(
+                state, kind, static_cast<guint>(i), window.identifier,
+                displayOrFallback(window.title, "Untitled window"), displayOrFallback(window.appId, "Application"), ""
+            ),
+            -1
+        );
       }
     }
-
     return list;
   }
 
-  GtkWidget* makeScrolledList(GtkWidget* list) {
+  GtkWidget* makeScrolledGrid(GtkWidget* list, const char* emptyText) {
     GtkWidget* scrolled = gtk_scrolled_window_new();
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
     gtk_widget_set_vexpand(scrolled, TRUE);
+    if (gtk_flow_box_get_child_at_index(GTK_FLOW_BOX(list), 0) == nullptr) {
+      // Parent the empty grid normally so selection queries remain valid.
+      GtkWidget* empty = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+      gtk_widget_set_visible(list, FALSE);
+      gtk_box_append(GTK_BOX(empty), list);
+      gtk_box_append(GTK_BOX(empty), makePlaceholder(emptyText));
+      list = empty;
+    }
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), list);
     return scrolled;
+  }
+
+  std::vector<size_t> visiblePreviews(const AppState& state) {
+    std::vector<size_t> indices;
+    for (size_t i = 0; i < state.previewStacks.size(); ++i) {
+      GtkWidget* preview = state.previewStacks[i];
+      if (!gtk_widget_get_mapped(preview)) {
+        continue;
+      }
+      GtkWidget* scrolled = gtk_widget_get_ancestor(preview, GTK_TYPE_SCROLLED_WINDOW);
+      graphene_rect_t bounds;
+      if (scrolled != nullptr
+          && gtk_widget_compute_bounds(preview, scrolled, &bounds)
+          && bounds.origin.y < gtk_widget_get_height(scrolled)
+          && bounds.origin.y + bounds.size.height > 0) {
+        indices.push_back(i);
+      }
+    }
+    return indices;
+  }
+
+  gboolean onPreviewResults(gpointer userData) {
+    auto& state = *static_cast<AppState*>(userData);
+    state.previews->request(visiblePreviews(state));
+    for (auto& result : state.previews->takeResults()) {
+      ++state.previewsLoaded;
+      GtkWidget* stack = state.previewStacks[result.index];
+      if (result.image != nullptr) {
+        const int width = gdk_pixbuf_get_width(result.image);
+        const int height = gdk_pixbuf_get_height(result.image);
+        cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
+        auto* pixels = gdk_pixbuf_get_pixels(result.image);
+        auto* target = cairo_image_surface_get_data(surface);
+        for (int y = 0; y < height; ++y) {
+          const auto* source = pixels + y * gdk_pixbuf_get_rowstride(result.image);
+          auto* row = reinterpret_cast<uint32_t*>(target + y * cairo_image_surface_get_stride(surface));
+          for (int x = 0; x < width; ++x) {
+            row[x] = (static_cast<uint32_t>(source[x * 3]) << 16)
+                | (static_cast<uint32_t>(source[x * 3 + 1]) << 8)
+                | source[x * 3 + 2];
+          }
+        }
+        cairo_surface_mark_dirty(surface);
+        GtkWidget* picture = gtk_drawing_area_new();
+        // Keep the grid's natural size independent of the captured image dimensions.
+        gtk_drawing_area_set_content_width(GTK_DRAWING_AREA(picture), 210);
+        gtk_drawing_area_set_content_height(GTK_DRAWING_AREA(picture), 132);
+        gtk_drawing_area_set_draw_func(
+            GTK_DRAWING_AREA(picture),
+            +[](GtkDrawingArea*, cairo_t* cr, int width, int height, gpointer data) {
+              auto* image = static_cast<cairo_surface_t*>(data);
+              const int w = cairo_image_surface_get_width(image);
+              const int h = cairo_image_surface_get_height(image);
+              const double scale = std::min(static_cast<double>(width) / w, static_cast<double>(height) / h);
+              cairo_translate(cr, (width - w * scale) / 2, (height - h * scale) / 2);
+              cairo_scale(cr, scale, scale);
+              cairo_set_source_surface(cr, image, 0, 0);
+              cairo_paint(cr);
+            },
+            surface, +[](gpointer data) { cairo_surface_destroy(static_cast<cairo_surface_t*>(data)); }
+        );
+        gtk_stack_add_named(GTK_STACK(stack), picture, "image");
+        gtk_stack_set_visible_child_name(GTK_STACK(stack), "image");
+        g_object_unref(result.image);
+      } else {
+        auto* label = GTK_LABEL(g_object_get_data(G_OBJECT(stack), "preview-label"));
+        gtk_label_set_text(label, "Preview unavailable");
+      }
+    }
+    if (state.previewsLoaded == state.previewStacks.size()) {
+      state.previewWatch = 0;
+      return G_SOURCE_REMOVE;
+    }
+    return G_SOURCE_CONTINUE;
   }
 
   void appendSelectedRows(AppState& state, GtkWidget* list, json& selections) {
@@ -613,7 +780,17 @@ namespace {
       return TRUE;
     }
 
+    GtkWidget* focus = gtk_window_get_focus(GTK_WINDOW(state->window));
+    if (state->multiple && keyval == GDK_KEY_space && focus != nullptr && GTK_IS_FLOW_BOX_CHILD(focus)) {
+      toggleSource(GTK_FLOW_BOX_CHILD(focus));
+      return TRUE;
+    }
+
     if (keyval == GDK_KEY_Return || keyval == GDK_KEY_KP_Enter) {
+      // Let focused controls (Cancel and the source tabs) handle their own activation.
+      if (focus != nullptr && GTK_IS_BUTTON(focus)) {
+        return FALSE;
+      }
       if (state->shareButton != nullptr && gtk_widget_get_sensitive(state->shareButton)) {
         share(*state);
       }
@@ -623,16 +800,25 @@ namespace {
     return FALSE;
   }
 
-  GtkWidget* makeContent(AppState& state, GtkWidget* header) {
+  GtkWidget* makeContent(AppState& state) {
     GtkWidget* content = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     GtkWidget* body = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_widget_set_vexpand(body, TRUE);
+    GtkWidget* heading = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
+    gtk_widget_add_css_class(heading, "picker-heading");
+    GtkWidget* title = makeLabel("Choose what to share", true, false);
+    gtk_widget_add_css_class(title, "picker-title");
+    gtk_box_append(GTK_BOX(heading), title);
+    GtkWidget* description =
+        makeLabel(state.multiple ? "Select one or more sources to share." : "Select a source to share.", false, true);
+    gtk_box_append(GTK_BOX(heading), description);
+    gtk_box_append(GTK_BOX(content), heading);
 
     if (state.showMonitors) {
-      state.outputList = makeListBox(state, RowKind::Monitor);
+      state.outputList = makeSourceGrid(state, RowKind::Monitor);
     }
     if (state.showWindows) {
-      state.windowList = makeListBox(state, RowKind::Window);
+      state.windowList = makeSourceGrid(state, RowKind::Window);
     }
 
     if (state.showMonitors && state.showWindows) {
@@ -641,14 +827,34 @@ namespace {
       gtk_widget_set_vexpand(stack, TRUE);
       gtk_stack_set_transition_type(GTK_STACK(stack), GTK_STACK_TRANSITION_TYPE_CROSSFADE);
       gtk_stack_switcher_set_stack(GTK_STACK_SWITCHER(switcher), GTK_STACK(stack));
-      gtk_header_bar_set_title_widget(GTK_HEADER_BAR(header), switcher);
-      gtk_stack_add_titled(GTK_STACK(stack), makeScrolledList(state.outputList), "screens", "Screens");
-      gtk_stack_add_titled(GTK_STACK(stack), makeScrolledList(state.windowList), "windows", "Windows");
+      gtk_widget_add_css_class(switcher, "source-tabs");
+      gtk_widget_remove_css_class(switcher, "linked");
+      gtk_widget_set_halign(switcher, GTK_ALIGN_START);
+      gtk_box_append(GTK_BOX(body), switcher);
+      gtk_stack_add_titled(
+          GTK_STACK(stack), makeScrolledGrid(state.outputList, "No screens available"), "screens", "Screens"
+      );
+      gtk_stack_add_titled(
+          GTK_STACK(stack), makeScrolledGrid(state.windowList, "No windows available"), "windows", "Windows"
+      );
+      g_signal_connect(
+          stack, "notify::visible-child", G_CALLBACK(+[](GObject* object, GParamSpec*, gpointer data) {
+            auto& state = *static_cast<AppState*>(data);
+            if (!state.multiple) {
+              const bool screens = std::strcmp(gtk_stack_get_visible_child_name(GTK_STACK(object)), "screens") == 0;
+              unselectList(screens ? state.windowList : state.outputList);
+            }
+          }),
+          &state
+      );
+      if (state.outputs.empty() && !state.windows.empty()) {
+        gtk_stack_set_visible_child_name(GTK_STACK(stack), "windows");
+      }
       gtk_box_append(GTK_BOX(body), stack);
     } else if (state.showMonitors) {
-      gtk_box_append(GTK_BOX(body), makeScrolledList(state.outputList));
+      gtk_box_append(GTK_BOX(body), makeScrolledGrid(state.outputList, "No screens available"));
     } else if (state.showWindows) {
-      gtk_box_append(GTK_BOX(body), makeScrolledList(state.windowList));
+      gtk_box_append(GTK_BOX(body), makeScrolledGrid(state.windowList, "No windows available"));
     } else {
       GtkWidget* placeholder = makePlaceholder("No share source types requested");
       gtk_widget_set_vexpand(placeholder, TRUE);
@@ -656,12 +862,11 @@ namespace {
       gtk_box_append(GTK_BOX(body), placeholder);
     }
 
-    GtkWidget* buttons = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-    gtk_widget_set_halign(buttons, GTK_ALIGN_END);
-    gtk_widget_set_margin_top(buttons, 12);
-    gtk_widget_set_margin_bottom(buttons, 12);
-    gtk_widget_set_margin_start(buttons, 12);
-    gtk_widget_set_margin_end(buttons, 12);
+    GtkWidget* buttons = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
+    gtk_widget_add_css_class(buttons, "picker-footer");
+    state.selectionLabel = makeLabel("Nothing selected", false, true);
+    gtk_widget_set_hexpand(state.selectionLabel, TRUE);
+    gtk_box_append(GTK_BOX(buttons), state.selectionLabel);
 
     GtkWidget* cancelButton = gtk_button_new_with_label("Cancel");
     state.shareButton = gtk_button_new_with_label("Share");
@@ -686,12 +891,11 @@ namespace {
     state->window = window;
     state->display = gtk_widget_get_display(window);
     gtk_widget_add_css_class(window, "umbriel-picker");
-    gtk_window_set_title(GTK_WINDOW(window), "Share");
-    gtk_window_set_default_size(GTK_WINDOW(window), 480, 420);
+    gtk_window_set_title(GTK_WINDOW(window), "Share a screen or window");
+    gtk_window_set_default_size(GTK_WINDOW(window), 760, 560);
 
-    GtkWidget* header = gtk_header_bar_new();
-    gtk_window_set_titlebar(GTK_WINDOW(window), header);
-    gtk_window_set_child(GTK_WINDOW(window), makeContent(*state, header));
+    // No custom titlebar: Umbriel owns the window decorations and their visibility.
+    gtk_window_set_child(GTK_WINDOW(window), makeContent(*state));
     gtk_window_set_default_widget(GTK_WINDOW(window), state->shareButton);
 
     GtkEventController* keyController = gtk_event_controller_key_new();
@@ -706,7 +910,27 @@ namespace {
           state->paletteFd, static_cast<GIOCondition>(G_IO_IN | G_IO_HUP | G_IO_ERR | G_IO_NVAL), onPaletteEvent, state
       );
     }
+    // Use GTK theme colors until the compositor sends its current palette.
+    if (!state->palette) {
+      applyPalette(
+          *state,
+          Palette{
+              .background = "@theme_bg_color",
+              .textPrimary = "@theme_fg_color",
+              .textMuted = "alpha(@theme_fg_color, 0.6)",
+              .accentPrimary = "@theme_selected_bg_color",
+              .accentSecondary = "@theme_selected_bg_color",
+              .warning = "",
+              .error = "",
+              .cornerRadius = 8,
+          }
+      );
+    }
     gtk_window_present(GTK_WINDOW(window));
+    if (!state->previewSources.empty()) {
+      state->previews = std::make_unique<xdpu::Previews>(state->previewSources);
+      state->previewWatch = g_timeout_add(100, onPreviewResults, state);
+    }
   }
 
 } // namespace
@@ -714,6 +938,10 @@ namespace {
 int main(int argc, char** argv) {
   AppState state = parseRequest(readStdin());
 
+  // GTK documents GTK_CSD=0 as delegating decorations to the window manager.
+  g_setenv("GTK_CSD", "0", TRUE);
+  // Cairo keeps this small snapshot UI inexpensive; respect renderer overrides.
+  g_setenv("GSK_RENDERER", "cairo", FALSE);
   gtk_init();
 
   GtkApplication* app = gtk_application_new("dev.noctalia.UmbrielSharePicker", G_APPLICATION_NON_UNIQUE);
@@ -722,6 +950,10 @@ int main(int argc, char** argv) {
   if (!state.responding) {
     cancel(state);
   }
+  if (state.previewWatch != 0) {
+    g_source_remove(state.previewWatch);
+  }
+  state.previews.reset();
   if (state.paletteWatch != 0) {
     g_source_remove(state.paletteWatch);
   }

--- a/src/picker/previews.cpp
+++ b/src/picker/previews.cpp
@@ -1,0 +1,284 @@
+#include "picker/previews.h"
+
+#include "loop/loop.h"
+#include "wayland/wayland.h"
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <drm_fourcc.h>
+#include <mutex>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <wayland-client.h>
+
+namespace xdpu {
+  namespace {
+    struct Capture {
+      std::unique_ptr<WaylandContext::CaptureSession> session;
+      std::unique_ptr<WaylandContext::CaptureFrame> frame;
+      wl_buffer* buffer = nullptr;
+      void* mapping = MAP_FAILED;
+      size_t size = 0;
+      int fd = -1;
+
+      ~Capture() {
+        frame.reset();
+        session.reset();
+        if (buffer != nullptr) {
+          wl_buffer_destroy(buffer);
+        }
+        if (mapping != MAP_FAILED) {
+          munmap(mapping, size);
+        }
+        if (fd >= 0) {
+          close(fd);
+        }
+      }
+    };
+
+    GdkPixbuf* thumbnail(const Capture& capture, uint32_t width, uint32_t height, uint32_t format, uint32_t transform) {
+      // Downsample directly from SHM so a second full-resolution copy is never needed.
+      const double scale = std::min(1.0, 512.0 / std::max(width, height));
+      const int w = std::max(1, static_cast<int>(width * scale));
+      const int h = std::max(1, static_cast<int>(height * scale));
+      GdkPixbuf* image = gdk_pixbuf_new(GDK_COLORSPACE_RGB, FALSE, 8, w, h);
+      if (image == nullptr) {
+        return nullptr;
+      }
+      const bool bgr = format == DRM_FORMAT_XBGR8888 || format == DRM_FORMAT_ABGR8888;
+      auto* pixels = static_cast<const uint32_t*>(capture.mapping);
+      auto* target = gdk_pixbuf_get_pixels(image);
+      const int stride = gdk_pixbuf_get_rowstride(image);
+      for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+          const uint32_t pixel =
+              pixels[(static_cast<size_t>(y) * height / h) * width + static_cast<size_t>(x) * width / w];
+          auto* rgb = target + y * stride + x * 3;
+          rgb[0] = (pixel >> (bgr ? 0 : 16)) & 0xff;
+          rgb[1] = (pixel >> 8) & 0xff;
+          rgb[2] = (pixel >> (bgr ? 16 : 0)) & 0xff;
+        }
+      }
+      // Undo the buffer transform: inverse rotation, then the optional horizontal flip.
+      const GdkPixbufRotation rotations[] = {
+          GDK_PIXBUF_ROTATE_NONE,
+          GDK_PIXBUF_ROTATE_CLOCKWISE,
+          GDK_PIXBUF_ROTATE_UPSIDEDOWN,
+          GDK_PIXBUF_ROTATE_COUNTERCLOCKWISE,
+      };
+      if ((transform & 3U) != 0) {
+        GdkPixbuf* rotated = gdk_pixbuf_rotate_simple(image, rotations[transform & 3U]);
+        g_object_unref(image);
+        image = rotated;
+      }
+      if (image != nullptr && (transform & 4U) != 0) {
+        GdkPixbuf* flipped = gdk_pixbuf_flip(image, TRUE);
+        g_object_unref(image);
+        image = flipped;
+      }
+      return image;
+    }
+
+    bool finishCaptureCleanup(Loop& loop, WaylandContext& wayland) {
+      // Capture destruction only queues protocol requests. Keep dispatching until
+      // the compositor has processed them, rather than parking an active capture
+      // session on an idle connection until the picker closes.
+      struct Sync {
+        Loop& loop;
+        bool done = false;
+      } sync{loop};
+      static constexpr wl_callback_listener listener = {
+          .done = +[](void* data, wl_callback*, uint32_t) {
+            auto& sync = *static_cast<Sync*>(data);
+            sync.done = true;
+            sync.loop.quit();
+          },
+      };
+      wl_callback* callback = wl_display_sync(wayland.display());
+      if (callback == nullptr) {
+        return false;
+      }
+      wl_callback_add_listener(callback, &listener, &sync);
+      // Never wait indefinitely on a compositor that stopped responding. The
+      // caller closes the private connection if cleanup cannot be acknowledged.
+      const int timeout = loop.addTimer(250, [&loop] { loop.quit(); });
+      wayland.flush();
+      if (timeout != 0 && wayland.connected()) {
+        loop.run();
+      }
+      loop.removeTimer(timeout);
+      wl_callback_destroy(callback);
+      return sync.done;
+    }
+
+    GdkPixbuf* captureSource(Loop& loop, WaylandContext& wayland, const PreviewSource& source, std::stop_token stop) {
+      Capture capture;
+      GdkPixbuf* result = nullptr;
+      bool done = false;
+      auto finish = [&] {
+        done = true;
+        loop.quit();
+      };
+      auto constraints = [&](const CaptureConstraints& info) {
+        // Resizes or unsupported formats leave a usable source with a fallback thumbnail.
+        if (done || capture.buffer != nullptr) {
+          finish();
+          return;
+        }
+        const uint32_t format = WaylandContext::preferredShmFormat(info.shmFormats);
+        if ((format != DRM_FORMAT_XRGB8888
+             && format != DRM_FORMAT_ARGB8888
+             && format != DRM_FORMAT_XBGR8888
+             && format != DRM_FORMAT_ABGR8888)
+            || info.bufferWidth == 0
+            || info.bufferHeight == 0
+            || info.bufferWidth > 16384
+            || info.bufferHeight > 16384) {
+          finish();
+          return;
+        }
+        const uint32_t stride = info.bufferWidth * 4;
+        capture.size = static_cast<size_t>(stride) * info.bufferHeight;
+        if (capture.size > 128 * 1024 * 1024) {
+          finish();
+          return;
+        }
+        capture.fd = memfd_create("umbriel-preview", MFD_CLOEXEC);
+        if (capture.fd < 0 || ftruncate(capture.fd, static_cast<off_t>(capture.size)) < 0) {
+          finish();
+          return;
+        }
+        capture.mapping = mmap(nullptr, capture.size, PROT_READ | PROT_WRITE, MAP_SHARED, capture.fd, 0);
+        if (capture.mapping == MAP_FAILED) {
+          finish();
+          return;
+        }
+        capture.buffer =
+            wayland.createShmBuffer(info.bufferWidth, info.bufferHeight, format, stride, capture.fd, capture.size);
+        capture.frame = wayland.captureFrame(
+            *capture.session, capture.buffer,
+            [&, width = info.bufferWidth, height = info.bufferHeight,
+             format](CaptureBuffer& buffer, uint64_t, uint32_t) {
+              result = thumbnail(capture, width, height, format, buffer.transform);
+              finish();
+            },
+            [&](CaptureFailureReason) { finish(); }
+        );
+      };
+      capture.session = source.monitor ? wayland.createOutputCapture(source.identifier, false, constraints)
+                                       : wayland.createToplevelCapture(source.identifier, false, constraints);
+      if (!capture.session) {
+        return nullptr;
+      }
+      capture.session->stoppedCb = finish;
+      // Check cancellation frequently, and bound sources that never produce a frame.
+      const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(1500);
+      int timer = 0;
+      std::function<void()> tick = [&] {
+        timer = 0;
+        if (stop.stop_requested() || std::chrono::steady_clock::now() >= deadline) {
+          finish();
+        } else {
+          timer = loop.addTimer(50, tick);
+        }
+      };
+      timer = loop.addTimer(50, tick);
+      if (!done && !stop.stop_requested() && wayland.connected()) {
+        loop.run();
+      }
+      if (timer != 0) {
+        loop.removeTimer(timer);
+      }
+      return result;
+    }
+  } // namespace
+
+  struct Previews::Impl {
+    const std::vector<PreviewSource> sources;
+    std::vector<bool> started;
+    std::deque<size_t> pending;
+    std::mutex mutex;
+    std::condition_variable_any workAvailable;
+    std::vector<PreviewResult> results;
+    std::jthread worker;
+
+    explicit Impl(std::vector<PreviewSource> sources)
+        : sources(std::move(sources)), started(this->sources.size(), false),
+          worker([this](std::stop_token stop) { run(stop); }) {}
+
+    void run(std::stop_token stop) {
+      std::unique_ptr<Loop> loop;
+      std::unique_ptr<WaylandContext> wayland;
+      while (!stop.stop_requested()) {
+        size_t index = 0;
+        {
+          std::unique_lock lock(mutex);
+          if (!workAvailable.wait(lock, stop, [this] { return !pending.empty(); })) {
+            break;
+          }
+          index = pending.front();
+          pending.pop_front();
+          started[index] = true;
+        }
+        GdkPixbuf* image = nullptr;
+        try {
+          // Even the Wayland connection is deferred until a card is visible.
+          if (!wayland) {
+            loop = std::make_unique<Loop>();
+            wayland = std::make_unique<WaylandContext>(*loop);
+          }
+          if (!stop.stop_requested() && wayland->connected()) {
+            image = captureSource(*loop, *wayland, sources[index], stop);
+            // All Capture members have now been destroyed. Flush and drain
+            // their destruction before publishing the thumbnail or idling.
+            if (!wayland->connected() || !finishCaptureCleanup(*loop, *wayland)) {
+              wayland.reset();
+            }
+          }
+        } catch (const std::exception& error) {
+          g_warning("umbriel-share-picker: preview unavailable: %s", error.what());
+        }
+        std::scoped_lock lock(mutex);
+        results.push_back({index, image});
+      }
+    }
+
+    ~Impl() {
+      worker.request_stop();
+      worker.join();
+      for (auto& result : results) {
+        g_clear_object(&result.image);
+      }
+    }
+  };
+
+  Previews::Previews(std::vector<PreviewSource> sources) : m_impl(std::make_unique<Impl>(std::move(sources))) {}
+  Previews::~Previews() = default;
+
+  void Previews::request(std::vector<size_t> indices) {
+    std::scoped_lock lock(m_impl->mutex);
+    m_impl->pending.clear();
+    for (size_t index : indices) {
+      if (index < m_impl->sources.size()
+          && !m_impl->started[index]
+          && std::ranges::find(m_impl->pending, index) == m_impl->pending.end()) {
+        m_impl->pending.push_back(index);
+      }
+    }
+    if (!m_impl->pending.empty()) {
+      m_impl->workAvailable.notify_one();
+    }
+  }
+
+  void Previews::stop() { m_impl->worker.request_stop(); }
+
+  std::vector<PreviewResult> Previews::takeResults() {
+    std::scoped_lock lock(m_impl->mutex);
+    std::vector<PreviewResult> results;
+    results.swap(m_impl->results);
+    return results;
+  }
+} // namespace xdpu

--- a/src/picker/previews.cpp
+++ b/src/picker/previews.cpp
@@ -168,8 +168,9 @@ namespace xdpu {
             [&](CaptureFailureReason) { finish(); }
         );
       };
-      capture.session = source.monitor ? wayland.createOutputCapture(source.identifier, false, constraints)
-                                       : wayland.createToplevelCapture(source.identifier, false, constraints);
+      capture.session = source.monitor
+          ? wayland.createOutputCapture(source.identifier, CaptureCursorMode::Hidden, constraints)
+          : wayland.createToplevelCapture(source.identifier, CaptureCursorMode::Hidden, constraints);
       if (!capture.session) {
         return nullptr;
       }

--- a/src/picker/previews.h
+++ b/src/picker/previews.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace xdpu {
+
+  struct PreviewSource {
+    bool monitor;
+    std::string identifier;
+  };
+
+  struct PreviewResult {
+    size_t index;
+    // Owned by the caller after takeResults(); null means capture was unavailable.
+    GdkPixbuf* image;
+  };
+
+  // One snapshot per requested source, captured sequentially on a private Wayland connection.
+  // Full-size buffers are released before the next capture; only thumbnails survive.
+  class Previews {
+  public:
+    explicit Previews(std::vector<PreviewSource> sources);
+    ~Previews();
+    // Replace pending work with the currently visible indices. Already captured or
+    // in-flight sources are ignored; hidden sources never open capture sessions.
+    void request(std::vector<size_t> indices);
+    void stop();
+    std::vector<PreviewResult> takeResults();
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+  };
+
+} // namespace xdpu

--- a/src/picker/style.css
+++ b/src/picker/style.css
@@ -3,91 +3,156 @@
   color: @TEXT_PRIMARY@;
 }
 
-/* The window contour belongs to Umbriel: it rounds the surface at the radius nested inside the border, which is
-   smaller than the configured outer radius. A client-side arc at the outer radius uncovers a crescent of background
-   in every corner, so the window and its decoration stay square and the compositor clips them. */
+/* The compositor owns the outer contour, including border and corner clipping. */
 .umbriel-picker,
 .umbriel-picker decoration {
   border-radius: 0;
 }
 
-.umbriel-picker button,
-.umbriel-picker row,
-.umbriel-picker list,
-.umbriel-picker scrolledwindow,
-.umbriel-picker stackswitcher,
-.umbriel-picker scrollbar,
-.umbriel-picker trough,
-.umbriel-picker slider {
-  border-radius: @RADIUS@;
+.umbriel-picker .picker-heading {
+  padding: 24px 24px 18px;
 }
 
-.umbriel-picker headerbar windowcontrols button,
-.umbriel-picker headerbar button.titlebutton,
-.umbriel-picker headerbar windowcontrols button > image,
-.umbriel-picker headerbar button.titlebutton > image {
-  border-radius: @RADIUS@;
-}
-
-.umbriel-picker headerbar {
-  border-radius: 0;
-}
-
-.umbriel-picker headerbar stackswitcher button {
-  border-radius: 0;
-}
-
-.umbriel-picker headerbar stackswitcher button:first-child {
-  border-radius: @RADIUS@ 0 0 @RADIUS@;
-}
-
-.umbriel-picker headerbar stackswitcher button:last-child {
-  border-radius: 0 @RADIUS@ @RADIUS@ 0;
-}
-
-.umbriel-picker headerbar,
-.umbriel-picker stack,
-.umbriel-picker scrolledwindow,
-.umbriel-picker list {
-  background-color: @BACKGROUND@;
-  color: @TEXT_PRIMARY@;
-}
-
-.umbriel-picker row {
-  color: @TEXT_PRIMARY@;
-}
-
-/* The primary accent marks what will be shared; the secondary one is only the pointer's hover feedback. Selected is
-   declared last so a hovered selection keeps the primary accent. */
-.umbriel-picker row:hover {
-  background-color: @ACCENT_SECONDARY@;
-  color: @BACKGROUND@;
-}
-
-.umbriel-picker row:selected {
-  background-color: @ACCENT_PRIMARY@;
-  color: @BACKGROUND@;
+.umbriel-picker .picker-title {
+  font-size: 1.45em;
 }
 
 .umbriel-picker .dim-label {
   color: @TEXT_MUTED@;
+  opacity: 1;
 }
 
-.umbriel-picker row:hover label,
-.umbriel-picker row:selected label {
+.umbriel-picker .source-tabs {
+  margin: 0 24px 8px;
+}
+
+.umbriel-picker .source-tabs button {
+  min-width: 90px;
+  margin-right: 8px;
+}
+
+.umbriel-picker .source-grid {
+  padding: 16px 24px;
+  background: transparent;
+}
+
+.umbriel-picker .source-card {
+  padding: 3px;
+  border: 2px solid alpha(@TEXT_PRIMARY@, 0.12);
+  border-radius: @RADIUS@;
+  background: alpha(@TEXT_PRIMARY@, 0.035);
+  color: @TEXT_PRIMARY@;
+  outline-offset: 2px;
+}
+
+.umbriel-picker .source-card:hover {
+  border-color: @ACCENT_SECONDARY@;
+  background: alpha(@ACCENT_SECONDARY@, 0.08);
+}
+
+.umbriel-picker .source-card:selected {
+  border-color: @ACCENT_PRIMARY@;
+  background: alpha(@ACCENT_PRIMARY@, 0.12);
+}
+
+.umbriel-picker .source-card:focus-visible {
+  outline: 2px solid @ACCENT_SECONDARY@;
+}
+
+.umbriel-picker .preview {
+  background: alpha(@TEXT_PRIMARY@, 0.06);
+  color: @TEXT_MUTED@;
+  border-radius: @RADIUS@;
+}
+
+.umbriel-picker .preview-caption,
+.umbriel-picker .source-detail {
+  font-size: 0.85em;
+}
+
+.umbriel-picker .card-labels {
+  padding: 12px 9px 10px;
+}
+
+.umbriel-picker .selection-check {
+  margin: 8px;
+  padding: 4px;
+  border-radius: @RADIUS@;
+  background: @ACCENT_PRIMARY@;
   color: @BACKGROUND@;
+  opacity: 0;
 }
 
-.umbriel-picker row:hover .dim-label,
-.umbriel-picker row:selected .dim-label {
-  opacity: 0.72;
+.umbriel-picker .source-card:selected .selection-check {
+  opacity: 1;
+}
+
+.umbriel-picker .picker-footer {
+  padding: 16px 24px;
+  border-top: 1px solid alpha(@TEXT_PRIMARY@, 0.12);
+}
+
+/* Reset theme gradients and shadows as well as colors, including interaction states. */
+.umbriel-picker button {
+  background-image: none;
+  background-color: alpha(@TEXT_PRIMARY@, 0.07);
+  color: @TEXT_PRIMARY@;
+  border: 1px solid alpha(@TEXT_PRIMARY@, 0.15);
+  border-radius: @RADIUS@;
+  box-shadow: none;
+  text-shadow: none;
+  padding: 9px 18px;
+  font-weight: 600;
+}
+
+.umbriel-picker button:hover {
+  background-image: none;
+  background-color: alpha(@ACCENT_SECONDARY@, 0.16);
+  border-color: @ACCENT_SECONDARY@;
+}
+
+.umbriel-picker button:checked,
+.umbriel-picker button:active {
+  background-image: none;
+  background-color: alpha(@ACCENT_PRIMARY@, 0.18);
+  border-color: @ACCENT_PRIMARY@;
+  color: @TEXT_PRIMARY@;
 }
 
 .umbriel-picker button.suggested-action {
+  background-image: none;
   background-color: @ACCENT_PRIMARY@;
+  border-color: @ACCENT_PRIMARY@;
   color: @BACKGROUND@;
 }
 
-.umbriel-picker button.suggested-action:focus-visible {
-  outline-color: @ACCENT_SECONDARY@;
+.umbriel-picker button.suggested-action:hover,
+.umbriel-picker button.suggested-action:active {
+  background-color: @ACCENT_SECONDARY@;
+  border-color: @ACCENT_SECONDARY@;
+}
+
+.umbriel-picker button:disabled,
+.umbriel-picker button.suggested-action:disabled {
+  background-image: none;
+  background-color: alpha(@TEXT_PRIMARY@, 0.06);
+  border-color: transparent;
+  color: @TEXT_MUTED@;
+  opacity: 0.55;
+}
+
+.umbriel-picker button:focus-visible {
+  outline: 2px solid @ACCENT_SECONDARY@;
+  outline-offset: 2px;
+}
+
+.umbriel-picker scrollbar {
+  background: transparent;
+}
+
+.umbriel-picker scrollbar slider {
+  background: alpha(@TEXT_MUTED@, 0.4);
+  border-radius: @RADIUS@;
+  min-width: 5px;
+  min-height: 5px;
 }

--- a/src/wayland/wayland.cpp
+++ b/src/wayland/wayland.cpp
@@ -460,7 +460,9 @@ namespace xdpu {
         .stopped = onSessionStopped,
     };
 
-    void onFrameTransform(void* /*data*/, ext_image_copy_capture_frame_v1* /*frame*/, uint32_t /*transform*/) {}
+    void onFrameTransform(void* data, ext_image_copy_capture_frame_v1* /*frame*/, uint32_t transform) {
+      static_cast<WaylandContext::CaptureFrame*>(data)->buffer.transform = transform;
+    }
 
     void onFrameDamage(
         void* /*data*/, ext_image_copy_capture_frame_v1* /*frame*/, int32_t /*x*/, int32_t /*y*/, int32_t /*width*/,
@@ -898,6 +900,12 @@ namespace xdpu {
     wl_shm_pool_destroy(pool);
     m_impl->flushDisplay();
     return buffer;
+  }
+
+  void WaylandContext::flush() {
+    if (connected()) {
+      m_impl->flushDisplay();
+    }
   }
 
   void WaylandContext::roundtrip() {

--- a/src/wayland/wayland.h
+++ b/src/wayland/wayland.h
@@ -40,6 +40,7 @@ namespace xdpu {
     uint32_t width = 0;
     uint32_t height = 0;
     uint32_t stride = 0;
+    uint32_t transform = 0;
     void* data = nullptr;
     size_t size = 0;
   };
@@ -147,6 +148,7 @@ namespace xdpu {
     createShmBuffer(uint32_t width, uint32_t height, uint32_t format, uint32_t stride, int fd, size_t size);
 
     void roundtrip();
+    void flush();
 
     static WaylandContext* defaultContext();
     static uint32_t preferredShmFormat(const std::vector<uint32_t>& formats);


### PR DESCRIPTION
- Capture deferred screen and window thumbnails over Wayland
- Support responsive multi-select cards with keyboard controls
- Delegate decorations to the compositor and document picker behavior

## Summary

<!-- What changed and why? Keep this brief. -->
Replace the screen and window lists with a responsive grid of preview cards, making sharing sources easier to identify.

- Load snapshots asynchronously as cards become visible.
- Support single and multiple selection with keyboard controls.
- Delegate window decorations to the compositor.
- Match buttons and selection states to Umbriel’s palette.

Window previews require the companion Umbriel fix for output membership and frame pacing across desktop and capture scenes. Older compositor builds can freeze captured applications when capture ends.
Fix pr here: https://github.com/noctalia-dev/umbriel/pull/167

## Testing

<!-- List the commands and manual checks you ran. If not tested, explain why. -->
- Debug and release builds pass.
- Picker clang-tidy and formatting checks pass.
- Verified screen/window previews, Share, Cancel, and response output in an isolated Umbriel session.
- Manually tested Discord window sharing and preview generation in a native session with the compositor fix.
- Installed the release build and verified the running backend.

https://github.com/user-attachments/assets/c6359157-762d-4281-8aa6-1bd3e111d23a

## Checklist

- [ ] This PR is ready for review, or is marked as a draft.
- [x] I ran the relevant build, test, or verification commands.
- [x] I manually tested the affected portal flow when practical.
- [x] I self-reviewed the changes.
